### PR TITLE
Feat: AWS EC2 배포를 위한 Mediasoup 및 네트워크 설정 추가

### DIFF
--- a/app/(main)/(routes)/workspace/[workspaceId]/friends/page.tsx
+++ b/app/(main)/(routes)/workspace/[workspaceId]/friends/page.tsx
@@ -37,11 +37,6 @@ const ListOfFriends = () => {
         <Image src="/robot.png" height={300} width={300} alt="empty" priority />
         <h2 className="text-lg font-medium">대화할 친구가 없어요. 새로운 친구를 추가해볼까요?</h2>
 
-        <div className="flex gap-2">
-          <Image src="/robot.png" height={300} width={300} alt="empty" priority />
-          <AddFriend />
-          <FriendRequestList />
-        </div>
       </div>
     );
   }

--- a/app/(main)/(routes)/workspace/[workspaceId]/friends/page.tsx
+++ b/app/(main)/(routes)/workspace/[workspaceId]/friends/page.tsx
@@ -37,6 +37,10 @@ const ListOfFriends = () => {
         <Image src="/robot.png" height={300} width={300} alt="empty" priority />
         <h2 className="text-lg font-medium">대화할 친구가 없어요. 새로운 친구를 추가해볼까요?</h2>
 
+        <div className="flex gap-2">
+          <AddFriend />
+          <FriendRequestList />
+        </div>
       </div>
     );
   }

--- a/server/src/mediasoup/manager.ts
+++ b/server/src/mediasoup/manager.ts
@@ -4,7 +4,7 @@ import { mediaCodecs } from "../config/mediasoupConfig";
 let worker: mediasoupTypes.Worker;
 
 export const initWorker = async () => {
-    worker = await createWorker({ rtcMinPort: 10000, rtcMaxPort: 10100 });
+    worker = await createWorker({ rtcMinPort: 2000, rtcMaxPort: 5000 });
     worker.on("died", () => {
         console.error(
             "[mediasoup] Worker가 예기치 못하게 죽었습니다, 2초 후 종료됩니다"
@@ -22,7 +22,10 @@ export const createRoomRouter = async () => {
 
 export const createWebRtcTransport = async (router: mediasoupTypes.Router) => {
     const transport = await router.createWebRtcTransport({
-        listenIps: [{ ip: "127.0.0.1" }],
+        listenIps: [{
+            ip: "0.0.0.0",
+            announcedIp: process.env.MEDIASOUP_ANNOUNCED_IP || "127.0.0.1",
+        },],
         enableUdp: true,
         enableTcp: true,
         preferUdp: true,


### PR DESCRIPTION
## 작업 개요
로컬 환경을 넘어 AWS EC2 인스턴스에 백엔드 서버를 배포하기 위한 인프라 설정을 진행. 

## 주요 변경 사항
- **Mediasoup WebRTC 설정**: `announcedIp`를 도입하여 외부 클라이언트가 서버의 퍼블릭 IP를 인식할 수 있도록 개선.
- **포트 범위 조정**: WebRTC 미디어 전송을 위해 UDP 포트 범위를 `2000-5000`으로 설정하고 AWS 보안 그룹에 반영.
- **환경 변수 관리**: 서버 IP 및 클라이언트 URL 등 보안이 필요한 정보를 `.env`로 분리하여 관리하도록 구조를 변경.

## 관련 이슈
- 테스트 결과: 로컬 환경 및 브라우저 보안 해제 시 정상 작동 확인.
- 다음 단계: Render.com을 활용하여 SSL이 적용된 자동화 배포 환경으로 전환 예정.